### PR TITLE
Add basic Google Maps example

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -30,6 +30,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+      - name: Inject Google Maps API Key
+        run: sed -i "s/YOUR_API_KEY/${GMAPSKEY}/" _config.yml
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+title: Google Maps API Shim Examples
+google_maps_api_key: YOUR_API_KEY

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ page.title }}</title>
+</head>
+<body>
+  {{ content }}
+</body>
+</html>

--- a/examples/basic-map/index.html
+++ b/examples/basic-map/index.html
@@ -1,0 +1,19 @@
+---
+layout: default
+title: Basic Map
+---
+
+<h1>Basic Google Map</h1>
+<div id="map" style="height: 400px; width: 100%;"></div>
+
+<script>
+  function initMap() {
+    const center = { lat: 40.6892, lng: -74.0445 }; // Statue of Liberty
+    new google.maps.Map(document.getElementById("map"), {
+      zoom: 8,
+      center: center,
+    });
+  }
+  window.initMap = initMap;
+</script>
+<script async defer src="https://maps.googleapis.com/maps/api/js?key={{ site.google_maps_api_key }}&callback=initMap"></script>

--- a/index.md
+++ b/index.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Google Maps API Shim Examples
+---
+
+# Google Maps API Shim Examples
+
+- [Basic Map](examples/basic-map/)


### PR DESCRIPTION
## Summary
- set up Jekyll site with minimal layout
- add "basic-map" example using Google Maps API
- configure workflow to inject API key during build

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685195cd36ac8329893a01335a54e73e